### PR TITLE
Ignore archived subscriptions on notifications

### DIFF
--- a/apps/subs/lib/subs/domain/subscription_repo.ex
+++ b/apps/subs/lib/subs/domain/subscription_repo.ex
@@ -52,7 +52,7 @@ defmodule Subs.SubscriptionRepo do
     query =
       from(
         s in Subscription,
-        where: s.next_bill_date >= ^from and s.next_bill_date <= ^to,
+        where: s.next_bill_date >= ^from and s.next_bill_date <= ^to and s.archived == false,
         preload: :user
       )
 

--- a/apps/subs/test/application/daily_notifications_builder_test.exs
+++ b/apps/subs/test/application/daily_notifications_builder_test.exs
@@ -119,6 +119,16 @@ defmodule Subs.Test.Application.DailyNotificationsBuilderTest do
     assert NaiveDateTime.to_date(subscription.next_bill_date) == NaiveDateTime.to_date(next_bill_date)
   end
 
+  test "ignores archived subscriptions" do
+    now = ~N[2018-01-01T00:00:00Z]
+    tomorrow = ~N[2018-01-02T00:00:00Z]
+
+    user = insert(:user)
+    insert(:complete_subscription, user: user, next_bill_date: tomorrow, archived: true)
+
+    assert [] = DailyNotificationsBuilder.build(now)
+  end
+
   describe "Weekly notification" do
     setup do
       [


### PR DESCRIPTION
Got a monthly notification and an archived subscription was listed.
Silly bug.